### PR TITLE
(update) Add new trigger for the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - master
-      - main
+  repository_dispatch:
+    types:
+      - update_documentation
 
 jobs:
     build-deploy:


### PR DESCRIPTION
The CI used to build the documentation can now be triggered when a repository dispatch event of type "update documentation" is received.