### PR TITLE
(fix) Force old astroid version to fix AutoAPI issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ myst-parser==4.0.1
 sphinx-copybutton==0.5.2
 sphinx-autoapi==3.6.0
 sphinx-togglebutton==0.3.2
+astroid==3.3.8


### PR DESCRIPTION
Latest astroid version makes AutoAPI fail to build. Downgrading to astroid==3.3.8.